### PR TITLE
store web-ext extension output as circle CI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 version: 2.1
 
 jobs:
-  Linting:
+  Build and lint:
     docker:
       - image: cimg/python:3.8.8-node
     steps:
@@ -20,6 +20,9 @@ jobs:
       - run:
           name: Run linting
           command: npm run lint
+      - store_artifacts:
+          path: ./web-ext-artifacts
+
 
   Firefox integration tests:
     docker:
@@ -34,12 +37,10 @@ jobs:
           command: export PATH=.:$PATH && npm run build:glean && npm run package:developer && npm run test:integration
       - store_artifacts:
           path: ./screenshots
-      - store_artifacts:
-          path: ./web-ext-artifacts
 
 workflows:
   version: 2
   ci:
     jobs:
-      - Linting
+      - Build and lint
       - Firefox integration tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
           command: export PATH=.:$PATH && npm run build:glean && npm run package:developer && npm run test:integration
       - store_artifacts:
           path: ./screenshots
+      - store_artifacts:
+          path: ./web-ext-artifacts
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
       - run:
           name: Run linting
           command: npm run lint
+      - run:
+          name: Package
+          command: npm run package && npm run package:developer
       - store_artifacts:
           path: ./web-ext-artifacts
 


### PR DESCRIPTION
This is a step towards automating more of the release process. Circle already builds the extension output files (.xpi), this causes it to archive them as well.