### PR TITLE
Make playtest mode work with Chrome and MV3

### DIFF
--- a/manifest.dev.json
+++ b/manifest.dev.json
@@ -54,5 +54,6 @@
   "options_ui": {
     "page": "public/options.html",
     "open_in_tab": true
-  }
+  },
+  "action": {}
 }

--- a/public/options.js
+++ b/public/options.js
@@ -36,6 +36,9 @@ document.getElementById("toggleEnabled").addEventListener("click", async event =
 });
 
 document.getElementById("download").addEventListener("click", async () => {
+    // Clear any outstanding browser badge text.
+    browser.action.setBadgeText({text: ""});
+
     // Get all data from local storage.
     // TODO we can pull this from glean more directly in the future.
     const storage = await browser.storage.local.get(null);

--- a/src/background.ts
+++ b/src/background.ts
@@ -165,9 +165,10 @@ if (enableDevMode) {
     }
   });
 
-  browser.storage.local.set({ "state": RunStates.Paused }).then(() =>
-    browser.storage.local.set({ "initialized": true }).then(() =>
-      browser.runtime.openOptionsPage()
-    )
-  );
+  browser.storage.local.set({ "initialized": true }).then(() => {
+
+    // Run by default in playtest/dev mode.
+    stateChangeCallback(RunStates.Running);
+    browser.action.onClicked.addListener(() => browser.runtime.openOptionsPage())
+  });
 }

--- a/src/pixelHuntStudy.ts
+++ b/src/pixelHuntStudy.ts
@@ -48,6 +48,19 @@ async function handlePixel(details: browser.WebRequest.OnBeforeRequestDetailsTyp
   // Facebook pixels live at `*://www.facebook.com/tr/`
   if (fbHostname.includes(url.hostname) && url.pathname.match(/^\/tr/)) {
 
+    if (enableDevMode) {
+      browser.action.getBadgeText({}).then((current) => {
+        if (current) {
+          let count = parseInt(current);
+          count++;
+          browser.action.setBadgeText({ text: count.toString() });
+        } else {
+          browser.action.setBadgeText({ text: "1" });
+        }
+      });
+
+    }
+
     // Pixels may be either HTTP GET requests for an image, or a POST from JS.
     // If a POST is detected, collect the form data submitted as well.
     let formData;


### PR DESCRIPTION
- start by default (otherwise the service worker restarting will reset things)
- link to options page from toolbar button (so UI is easier to find)
- show badge count for observed pixels (so it is clear to the user that things are working)