### PR TITLE
correct path for webextension-polyfill copies

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -86,7 +86,7 @@ export default (cliArgs) => {
                 copy({
                     targets: [{
                         src: [
-                            "node_modules/webextension-polyfill/browser-polyfill.min.js",
+                            "node_modules/webextension-polyfill/dist/browser-polyfill.min.js",
                         ],
                         dest: "dist/",
                     }],
@@ -95,7 +95,7 @@ export default (cliArgs) => {
                 copy({
                     targets: [{
                         src: [
-                            "node_modules/webextension-polyfill/browser-polyfill.min.js.map",
+                            "node_modules/webextension-polyfill/dist/browser-polyfill.min.js.map",
                         ],
                         dest: "dist/",
                     }],


### PR DESCRIPTION
It turns out https://github.com/mozilla-rally/facebook-pixel-hunt/pull/148 was still depending on that `browser-polyfill` target, I had the paths wrong for the copy() in the rollup config.